### PR TITLE
Show route#9

### DIFF
--- a/app/assets/stylesheets/pesentation.scss
+++ b/app/assets/stylesheets/pesentation.scss
@@ -115,3 +115,13 @@ display:flex;
 justify-content: center;
 align-items: center;
 }
+
+//////// ↓前のピンからの経路」を表示するための追加↓ ////////
+//デフォルトで作成される「ルート表示用ピン」は表示しない
+p.yolp-rtlistnum0{
+  display: none;
+}
+p.yolp-sicn, p.yolp-gicn {
+  display: none;
+}
+//////// ↑前のピンからの経路」を表示するための追加↑ ////////

--- a/app/controllers/plan_pins_controller.rb
+++ b/app/controllers/plan_pins_controller.rb
@@ -116,6 +116,8 @@ class PlanPinsController < ApplicationController
 
   end
 
+
+
 private
 
   def set_plan_pin
@@ -127,7 +129,7 @@ private
   end
 
   def plan_pin_params
-    params.require(:plan_pin).permit(:plan_id, :drawing_pin_id,:plan_pin_name,:plan_pin_article)
+    params.require(:plan_pin).permit(:plan_id, :drawing_pin_id,:plan_pin_name,:plan_pin_article,:route)
   end
 
   def set_drawing_pin(pin_id)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -96,6 +96,24 @@ class PlansController < ApplicationController
 
   end
 
+
+  def reset_pin_route
+  # 所属しているピンの経路を一括で変更する
+    set_plan
+
+    if @plan.reset_route(params[:plan][:route])
+      flash[:notice] = "所属している📍の経路を再設定しました。"
+    else
+      flash[:danger] = @plan.errors.messages[:route]
+    end
+
+    # respond_to do |format|
+    #   format.js { render :reset_pin_route }
+    # end
+
+  end
+
+
   def presentation
     set_plan
 

--- a/app/helpers/plan_pins_helper.rb
+++ b/app/helpers/plan_pins_helper.rb
@@ -1,2 +1,47 @@
 module PlanPinsHelper
+
+  #セレクトボックス作成のために、（引数がTならば現在ユーザーの）プラン情報を取得
+  def get_routes_as_selectbox_info(has_blank: false)
+  # def get_routes_as_selectbox_info(planpin_id: "", has_blank: false)
+
+    # plan_pins = Plan.find(plan_id).order(:created_at)
+    #
+    # if only_currentuser
+    #   plans = Plan.find(plan_id).order(:created_at)
+    # else
+    #   plans = Plan.all.order(:created_at)
+    # end
+
+    if has_blank==true
+      box_info = (0..3).map{|route_type| [get_route_name(route_type),route_type]}.unshift(["",""])
+    else
+      box_info = (0..3).map{|route_type| [get_route_name(route_type),route_type]}
+    end
+
+    return box_info
+        # return [box_info,planpin_id]
+
+  end
+
+  def get_route_name(route_type)
+
+    case route_type
+
+    when 0
+      return "非表示"
+
+    when 1
+      return "直線"
+
+    when 2
+      return  "道程"
+
+    when 3
+      return  "道程(車：不使用)"
+
+    else
+      return "想定外の種類"
+    end
+  end
+
 end

--- a/app/javascript/controllers/presentation_controller.js
+++ b/app/javascript/controllers/presentation_controller.js
@@ -44,6 +44,53 @@ export default class extends Controller {
             var icon = new Y.Icon('https://chart.googleapis.com/chart?chst=d_map_pin_letter_withshadow&chld=' + (i+1) +'|00BFFF|000000');
             var marker = new Y.Marker(current_location,{icon: icon,title: this.pins[i].pin_name});
 
+            //////// ↓前のピンからの経路」を表示するための追加↓ ////////
+            if(i > 0 ){
+              switch (this.pins[i].route){
+                // case 0:
+                //前のピンからの経路タイプが「0：非表示」である場合は、何もしない
+
+                case 1:
+                  //前のピンからの経路タイプが「1：青い直線表示」である場合
+                  var line_style = new Y.Style("0000FF", 1.6, 0.8);
+                  var line_latlngs = []
+
+                  line_latlngs.push(new Y.LatLng(this.pins[i-1].latitude,this.pins[i-1].longitude))
+                  line_latlngs.push(new Y.LatLng(this.pins[i].latitude,this.pins[i].longitude))
+
+                  var polyline = new Y.Polyline(line_latlngs, {strokeStyle: line_style});this.map.addFeature(polyline);
+                  break;
+
+                case 2:
+                case 3:
+                  //経路探索レイヤーを生成・追加します。
+                  var route = new Y.RouteSearchLayer();
+                  this.map.addLayer(route);
+                  var latlngs = [new Y.LatLng(this.pins[i-1].latitude,this.pins[i-1].longitude),
+                                 new Y.LatLng(this.pins[i].latitude,this.pins[i].longitude)]
+
+                  if(this.pins[i].route==2){
+                    route.execute( latlngs);
+
+                  }else{
+                    route.execute( latlngs, {"useCar": false });
+                  }
+                    //
+                    //
+                    //
+                    //
+                    // console.log(this.pins[i].position);
+                    //                     console.log("R");
+                    // console.log(this.pins[i].route);
+                // case 3:
+
+              }
+
+
+
+            }
+            //////// ↑前のピンからの経路」を表示するための追加↑ ////////
+
             break;
 
           case "workbox":

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -13,7 +13,7 @@ class Plan < ApplicationRecord
 
   #パスワードの存在確認……
   validate :chk_password_existence, on: :update
-  
+
   validates :comment ,length: {maximum: 40}
 
   def chk_password_existence
@@ -48,6 +48,23 @@ class Plan < ApplicationRecord
 
   ####↑↑↑↑アソシエーション情報↑↑↑↑############
 
+  ##所属しているピンの経路情報を一括で更新（リセット）する
+  def reset_route(route_info)
 
+    if route_info == ""
+      errors.add(:route , "経路を選択してください。")
+      return false
+    end
+
+    if not ["0","1","2","3"].include?(route_info)
+      errors.add(:route , "経路が不正です。")
+      return false
+    end
+
+    plan_pins.update_all(route: route_info)
+
+    return true
+
+  end
 
 end

--- a/app/service/sql_service/get_replaced_pin_info.rb
+++ b/app/service/sql_service/get_replaced_pin_info.rb
@@ -135,6 +135,7 @@ module GetReplacedPinInfo
     sql += " ,drawing_pins.image "
     sql += " ,drawing_pins.public_div "
     sql += " ,plan_pins.position "
+    sql += " ,plan_pins.route "
 
     sql += " from plan_pins"
 

--- a/app/views/layouts/_show_danger_msg.html.erb
+++ b/app/views/layouts/_show_danger_msg.html.erb
@@ -16,3 +16,5 @@
       </ul>
     </div>
   <% end %>
+
+<% flash[:danger]="" %>

--- a/app/views/layouts/_show_notice_msg.html.erb
+++ b/app/views/layouts/_show_notice_msg.html.erb
@@ -4,3 +4,5 @@
       <h6><%= notice %></h6>
     </div>
   <% end %>
+
+  <% notice="" %>

--- a/app/views/plan_pins/edit.html.erb
+++ b/app/views/plan_pins/edit.html.erb
@@ -29,6 +29,10 @@
 </div>
 
 
+<div class="line_info">
+  <%= form.label "前の📍からの経路" ,class: "line_content_1" %>
+  <%= form.select :route, get_routes_as_selectbox_info() , {:selected => @plan_pin.route},class: "line_content_2_large_interval"  %>
+</div>
 
 <div class="line_info">
   <%= form.label :plan_pin_name ,class: "line_content_1" %>

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -95,5 +95,23 @@
   <div class="line_info">
     <%= form.submit id:"btn_save" , class: 'btn btn-primary line_content_btn'%>
   </div>
-  
+
+<% end %>
+
+<!-- メッセージとか -->
+<p id="route_notice_msg"><%= render 'layouts/show_notice_msg' %></p>
+<p id="route_danger_msg"><%= render 'layouts/show_danger_msg' %></p>
+
+<h4>【経路一括設定】</h4>
+<%= form_with(model: @plan,url: reset_pin_route_plan_path, method: :patch , remote: true) do |form| %>
+
+  <div class="line_info">
+
+    所属する📍間の経路を、全て
+    <%= form.select :route, get_routes_as_selectbox_info(has_blank: true) %>
+    に
+    <%= form.submit "変更"  %>
+    する。
+  </div>
+
 <% end %>

--- a/app/views/plans/reset_pin_route.js.erb
+++ b/app/views/plans/reset_pin_route.js.erb
@@ -1,0 +1,3 @@
+$("#route_notice_msg").html("<%= j(render 'layouts/show_notice_msg') %>")
+
+$("#route_danger_msg").html("<%= j(render 'layouts/show_danger_msg') %>")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
       post :presentation_password_chk
       # ↓一覧画面での検索用
       get :search_pin_for
+      # ↓所属するpinについて、経路を一括で変更する
+      patch :reset_pin_route
     end
 
 
@@ -38,6 +40,7 @@ Rails.application.routes.draw do
     # resources :plan_pins, only: [:create,:destroy,:show,:new,:edit,:update] do
       collection do
         post :create_in_planform
+
       end
       member do
         delete :destroy_in_planform

--- a/db/migrate/20190811033123_add_route_to_plan_pins.rb
+++ b/db/migrate/20190811033123_add_route_to_plan_pins.rb
@@ -1,0 +1,9 @@
+class AddRouteToPlanPins < ActiveRecord::Migration[5.2]
+  def up
+    add_column :plan_pins, :route, :integer, default:1,  null: false
+  end
+
+  def down
+    remove_column :plan_pins, :route, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_154423) do
+ActiveRecord::Schema.define(version: 2019_08_11_033123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2019_07_08_154423) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position", default: 0, null: false
+    t.integer "route", default: 1, null: false
     t.index ["drawing_pin_id"], name: "index_plan_pins_on_drawing_pin_id"
     t.index ["plan_id"], name: "index_plan_pins_on_plan_id"
   end


### PR DESCRIPTION
・DB変更、プランピンに「経路種別」項目追加
・プランピン更新画面に「経路種別」項目変更機能を追加
・プラン更新画面に（所属するピンの）「経路種別」項目一括変更機能を追加
・「経路種別」に合わせて、プレゼン画面で経路が表示されるようにした